### PR TITLE
Fix silent failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,4 +95,4 @@ const mainAsync = async () => {
     console.log('FillOrder transaction receipt: ', txReceipt);
 };
 
-mainAsync().catch(err => console.log);
+mainAsync().catch(console.error);


### PR DESCRIPTION
Failures in the `mainAsync` function was not logged to console.log due to the `err` parameter not being passed into console.log correctly.